### PR TITLE
ゲームオーバー後のリスタート機能を修正

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -32,6 +32,7 @@ function setup() {
 }
 
 function startGame() {
+    resetGame();
     isGameStarted = true;
     gameStartTime = millis();
     startButton.attribute('disabled', '');


### PR DESCRIPTION
ゲームオーバー後にスタートボタンを押してもリスタートしない問題を修正しました。

- startGame()関数内でresetGame()を呼び出すように変更
- これにより、ゲームオーバー後にスタートボタンを押すとゲームが正しくリスタートするようになりました。