### PR TITLE
縦方向の移動時のネズミの動きを修正

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -97,24 +97,6 @@ function draw() {
         // ゲーム中
         score = floor((millis() - gameStartTime) / 1000);
         
-        // キー入力の処理
-        if (isGameStarted && !isGameOver) {
-            if (keyIsPressed) {
-                if (keyCode === LEFT_ARROW) {
-                    mouse.x -= mouse.speed;
-                } else if (keyCode === RIGHT_ARROW) {
-                    mouse.x += mouse.speed;
-                } else if (keyCode === UP_ARROW) {
-                    mouse.y -= mouse.speed;
-                } else if (keyCode === DOWN_ARROW) {
-                    mouse.y += mouse.speed;
-                }
-                
-                // 画面外に出ないように制限
-                mouse.x = constrain(mouse.x, 30 + mouse.size/2, width - 30 - mouse.size/2);
-                mouse.y = constrain(mouse.y, 30 + mouse.size/2, height - 30 - mouse.size/2);
-            }
-        }
         
         updateCatPosition();
         drawCat();


### PR DESCRIPTION
## 変更内容

- draw関数内のキー入力処理を削除し、keyPressed関数に処理を一本化
- これにより、縦方向の移動時(UP_ARROWとDOWN_ARROW)でもmouse.isMovingの切り替えが正しく機能するようになりました

## 動作確認項目
- [ ] 上下左右の矢印キーでネズミが移動すること
- [ ] 縦方向(上下)の移動時もネズミの耳、目、ヒゲの動きが正しく変化すること