### PR TITLE
スマートフォン向けの方向ボタンを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,14 @@
     <div class="game-container">
         <main id="main"></main>
         <button id="startButton" class="start-button">スタート</button>
+        <div class="direction-buttons">
+            <button id="upButton" class="direction-button">↑</button>
+            <div class="horizontal-buttons">
+                <button id="leftButton" class="direction-button">←</button>
+                <button id="rightButton" class="direction-button">→</button>
+            </div>
+            <button id="downButton" class="direction-button">↓</button>
+        </div>
     </div>
 </body>
 </html>

--- a/sketch.js
+++ b/sketch.js
@@ -46,6 +46,12 @@ let score = 0;
 let bestScore = 0;
 let isGameStarted = false;
 let startButton;
+let directionButtons = {
+    up: null,
+    down: null,
+    left: null,
+    right: null
+};
 
 // キーの状態を保持する変数
 let keys = {
@@ -61,6 +67,15 @@ function setup() {
     
     startButton = select('#startButton');
     startButton.mousePressed(startGame);
+
+    // 方向ボタンの設定
+    directionButtons.up = select('#upButton');
+    directionButtons.down = select('#downButton');
+    directionButtons.left = select('#leftButton');
+    directionButtons.right = select('#rightButton');
+
+    // タッチイベントの設定
+    setupDirectionButtons();
     
     resetGame();
 }
@@ -424,6 +439,43 @@ function mousePressed() {
         if (isGameOver) {
             resetGame();
         }
+    }
+}
+
+function setupDirectionButtons() {
+    // ボタンを押したときの処理
+    function handleButtonPress(key) {
+        keys[key] = true;
+    }
+
+    // ボタンを離したときの処理
+    function handleButtonRelease(key) {
+        keys[key] = false;
+    }
+
+    // マウス/タッチイベントの設定
+    for (let direction in directionButtons) {
+        let button = directionButtons[direction];
+        
+        // mousedown/touchstartイベント
+        button.mousePressed(() => handleButtonPress(direction));
+        button.elt.addEventListener('touchstart', (e) => {
+            e.preventDefault();
+            handleButtonPress(direction);
+        });
+
+        // mouseup/touchendイベント
+        button.mouseReleased(() => handleButtonRelease(direction));
+        button.elt.addEventListener('touchend', (e) => {
+            e.preventDefault();
+            handleButtonRelease(direction);
+        });
+
+        // タッチデバイスでボタンの外に指が移動した場合
+        button.elt.addEventListener('touchcancel', (e) => {
+            e.preventDefault();
+            handleButtonRelease(direction);
+        });
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -27,7 +27,7 @@ canvas {
 .start-button {
     padding: 10px 30px;
     font-size: 18px;
-    background-color: #4CAF50;
+    background-color: #4a90e2;
     color: white;
     border: none;
     border-radius: 5px;
@@ -36,7 +36,7 @@ canvas {
 }
 
 .start-button:hover {
-    background-color: #45a049;
+    background-color: #357abd;
 }
 
 .start-button:disabled {
@@ -61,7 +61,7 @@ canvas {
     width: 50px;
     height: 50px;
     font-size: 24px;
-    background-color: #4CAF50;
+    background-color: #4a90e2;
     color: white;
     border: none;
     border-radius: 8px;
@@ -76,11 +76,11 @@ canvas {
 }
 
 .direction-button:active {
-    background-color: #45a049;
+    background-color: #357abd;
 }
 
 @media (hover: hover) {
     .direction-button:hover {
-        background-color: #45a049;
+        background-color: #357abd;
     }
 }

--- a/style.css
+++ b/style.css
@@ -27,7 +27,7 @@ canvas {
 .start-button {
     padding: 10px 30px;
     font-size: 18px;
-    background-color: #4a90e2;
+    background-color: #4CAF50;
     color: white;
     border: none;
     border-radius: 5px;
@@ -36,7 +36,7 @@ canvas {
 }
 
 .start-button:hover {
-    background-color: #357abd;
+    background-color: #45a049;
 }
 
 .start-button:disabled {

--- a/style.css
+++ b/style.css
@@ -43,3 +43,44 @@ canvas {
     background-color: #cccccc;
     cursor: not-allowed;
 }
+
+.direction-buttons {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    margin-top: 20px;
+}
+
+.horizontal-buttons {
+    display: flex;
+    gap: 20px;
+}
+
+.direction-button {
+    width: 50px;
+    height: 50px;
+    font-size: 24px;
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.direction-button:active {
+    background-color: #45a049;
+}
+
+@media (hover: hover) {
+    .direction-button:hover {
+        background-color: #45a049;
+    }
+}


### PR DESCRIPTION
スマートフォンでも遊べるように、画面上に方向ボタンを追加しました。

## 変更内容
- HTMLに4方向の矢印ボタンを追加
- CSSでボタンのスタイリングを実装(スマートフォン対応)
- JavaScriptでタッチイベントとマウスイベントの処理を追加

## 動作確認方法
1. スマートフォンまたはタブレットでゲームを開く
2. スタートボタンを押してゲームを開始
3. 画面下部の矢印ボタンでネズミを操作できることを確認