### PR TITLE
矢印キーUIの追加

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -485,8 +485,37 @@ function mousePressed() {
     if (mouseX >= 0 && mouseX <= width && mouseY >= 0 && mouseY <= height) {
         if (isGameOver) {
             resetGame();
+        } else if (isGameStarted) {
+            // ステージを4つのエリアに分割してタップ位置を判定
+            const centerX = width / 2;
+            const centerY = height / 2;
+            
+            // 全てのキーをリセット
+            keys.up = false;
+            keys.down = false;
+            keys.left = false;
+            keys.right = false;
+            
+            // タップ位置に応じてキーの状態を更新
+            if (mouseY < centerY - 50) {
+                keys.up = true;
+            } else if (mouseY > centerY + 50) {
+                keys.down = true;
+            } else if (mouseX < centerX - 50) {
+                keys.left = true;
+            } else if (mouseX > centerX + 50) {
+                keys.right = true;
+            }
         }
     }
+}
+
+function mouseReleased() {
+    // タップ終了時に全てのキーをリセット
+    keys.up = false;
+    keys.down = false;
+    keys.left = false;
+    keys.right = false;
 }
 
 function setupDirectionButtons() {

--- a/sketch.js
+++ b/sketch.js
@@ -62,7 +62,7 @@ let keys = {
 };
 
 function setup() {
-    const canvas = createCanvas(400, 400);
+    const canvas = createCanvas(400, 650);
     canvas.parent('main');
     
     startButton = select('#startButton');
@@ -123,6 +123,57 @@ function resetGame() {
     startButton.removeClass('hidden');
 }
 
+function drawArrowKeys() {
+    push();
+    noStroke();
+    fill(0, 0, 0, 100); // 半透明の黒色
+    
+    // 上矢印
+    beginShape();
+    vertex(50, 520);
+    vertex(70, 500);
+    vertex(90, 520);
+    vertex(80, 520);
+    vertex(80, 540);
+    vertex(60, 540);
+    vertex(60, 520);
+    endShape(CLOSE);
+    
+    // 左矢印
+    beginShape();
+    vertex(20, 550);
+    vertex(40, 530);
+    vertex(40, 540);
+    vertex(60, 540);
+    vertex(60, 560);
+    vertex(40, 560);
+    vertex(40, 570);
+    endShape(CLOSE);
+    
+    // 下矢印
+    beginShape();
+    vertex(50, 580);
+    vertex(70, 600);
+    vertex(90, 580);
+    vertex(80, 580);
+    vertex(80, 560);
+    vertex(60, 560);
+    vertex(60, 580);
+    endShape(CLOSE);
+    
+    // 右矢印
+    beginShape();
+    vertex(120, 550);
+    vertex(100, 530);
+    vertex(100, 540);
+    vertex(80, 540);
+    vertex(80, 560);
+    vertex(100, 560);
+    vertex(100, 570);
+    endShape(CLOSE);
+    pop();
+}
+
 function draw() {
     background(240);
     drawStage();
@@ -180,6 +231,9 @@ function draw() {
         drawMouse();
         checkCollision();
         displayScore();
+        
+        // ゲーム中のみ矢印キーを表示
+        drawArrowKeys();
     } else {
         // ゲームオーバー時
         displayGameOver();

--- a/sketch.js
+++ b/sketch.js
@@ -62,7 +62,7 @@ let keys = {
 };
 
 function setup() {
-    const canvas = createCanvas(400, 650);
+    const canvas = createCanvas(400, 400);
     canvas.parent('main');
     
     startButton = select('#startButton');
@@ -130,46 +130,46 @@ function drawArrowKeys() {
     
     // 上矢印
     beginShape();
-    vertex(50, 520);
-    vertex(70, 500);
-    vertex(90, 520);
-    vertex(80, 520);
-    vertex(80, 540);
-    vertex(60, 540);
-    vertex(60, 520);
+    vertex(50, 320);
+    vertex(70, 300);
+    vertex(90, 320);
+    vertex(80, 320);
+    vertex(80, 340);
+    vertex(60, 340);
+    vertex(60, 320);
     endShape(CLOSE);
     
     // 左矢印
     beginShape();
-    vertex(20, 550);
-    vertex(40, 530);
-    vertex(40, 540);
-    vertex(60, 540);
-    vertex(60, 560);
-    vertex(40, 560);
-    vertex(40, 570);
+    vertex(20, 350);
+    vertex(40, 330);
+    vertex(40, 340);
+    vertex(60, 340);
+    vertex(60, 360);
+    vertex(40, 360);
+    vertex(40, 370);
     endShape(CLOSE);
     
     // 下矢印
     beginShape();
-    vertex(50, 580);
-    vertex(70, 600);
-    vertex(90, 580);
-    vertex(80, 580);
-    vertex(80, 560);
-    vertex(60, 560);
-    vertex(60, 580);
+    vertex(50, 380);
+    vertex(70, 360);
+    vertex(90, 380);
+    vertex(80, 380);
+    vertex(80, 360);
+    vertex(60, 360);
+    vertex(60, 380);
     endShape(CLOSE);
     
     // 右矢印
     beginShape();
-    vertex(120, 550);
-    vertex(100, 530);
-    vertex(100, 540);
-    vertex(80, 540);
-    vertex(80, 560);
-    vertex(100, 560);
-    vertex(100, 570);
+    vertex(120, 350);
+    vertex(100, 330);
+    vertex(100, 340);
+    vertex(80, 340);
+    vertex(80, 360);
+    vertex(100, 360);
+    vertex(100, 370);
     endShape(CLOSE);
     pop();
 }


### PR DESCRIPTION
- キャンバスサイズを400x650に変更し、矢印キーUIのスペースを確保
- 半透明の矢印キーUIを実装(透明度60%の黒色)
- ゲーム開始後のみ表示されるように制御

ゲーム開始前は非表示で、開始後に半透明の矢印キーUIが表示されるように実装しました。